### PR TITLE
Recommend a channel with a URL parameter

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,16 @@
               </div>
             </a>
           </div>
+          <!-- This block is hidden unless a query param like `?recommendChannel=javascript` is in the url -->
+          <div id="recommend-channel-container" class="flex items-center justify-center center" style="display:none" aria-hidden="true">
+            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="http://dctech.slack.com">
+              <div>
+                <div class="f3 mb2">4</div>
+                <div>Join Channels</div>
+                <div class="gray">Check out <span id="recommend-channel"></span></div>
+              </div>
+            </a>
+          </div>
         </div>
         <div class="flex flex-wrap space-between mt4">
           <div class="flex items-center justify-center center">
@@ -72,5 +82,27 @@
         </div>
       </div>
     </div>
+  <script type="text/javascript">
+    // From https://css-tricks.com/snippets/javascript/get-url-variables/
+    function getQueryVariable(variable) {
+      var query = window.location.search.substring(1);
+      var vars = query.split("&");
+      for (var i=0;i<vars.length;i++) {
+        var pair = vars[i].split("=");
+        if(pair[0] == variable){return pair[1];}
+      }
+      return(false);
+    }
+
+    var containerElem = document.getElementById("recommend-channel-container");
+    var channelElem = document.getElementById("recommend-channel");
+    var channel = getQueryVariable("recommendChannel");
+
+    if (channel) {
+      channelElem.textContent = "#" + channel.toString();
+      // Remove "display: none" to unhide.
+      containerElem.style.display = null;
+    }
+  </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -57,13 +57,13 @@
               </div>
             </a>
           </div>
-          <!-- This block is hidden unless a query param like `?recommendChannel=javascript` is in the url -->
-          <div id="recommend-channel-container" class="flex items-center justify-center center" style="display:none" aria-hidden="true">
+          <!-- This block is hidden unless a query param like `?recommendedChannel=javascript` is in the url -->
+          <div id="recommended-channel-container" class="flex items-center justify-center center" style="display:none" aria-hidden="true">
             <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="http://dctech.slack.com">
               <div>
                 <div class="f3 mb2">4</div>
                 <div>Join Channels</div>
-                <div class="gray">Check out <span id="recommend-channel"></span></div>
+                <div class="gray">Check out <span id="recommended-channel"></span></div>
               </div>
             </a>
           </div>
@@ -94,9 +94,9 @@
       return(false);
     }
 
-    var containerElem = document.getElementById("recommend-channel-container");
-    var channelElem = document.getElementById("recommend-channel");
-    var channel = getQueryVariable("recommendChannel");
+    var channelContainerElem = document.getElementById("recommended-channel-container");
+    var channelElem = document.getElementById("recommended-channel");
+    var channel = getQueryVariable("recommendedChannel");
 
     if (channel) {
       channelElem.textContent = "#" + channel.toString();

--- a/src/index.html
+++ b/src/index.html
@@ -59,11 +59,11 @@
           </div>
           <!-- This block is hidden unless a query param like `?recommendedChannel=javascript` is in the url -->
           <div id="recommended-channel-container" class="flex items-center justify-center center" style="display:none" aria-hidden="true">
-            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="http://dctech.slack.com">
+            <a id="recommended-channel-link" class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="http://dctech.slack.com">
               <div>
                 <div class="f3 mb2">4</div>
-                <div>Join Channels</div>
-                <div class="gray">Check out <span id="recommended-channel"></span></div>
+                <div>Join Channel</div>
+                <div class="gray"><span id="recommended-channel"></span></div>
               </div>
             </a>
           </div>
@@ -95,13 +95,16 @@
     }
 
     var channelContainerElem = document.getElementById("recommended-channel-container");
+    var channelLinkElem = document.getElementById("recommended-channel-link");
     var channelElem = document.getElementById("recommended-channel");
     var channel = getQueryVariable("recommendedChannel");
 
     if (channel) {
-      channelElem.textContent = "#" + channel.toString();
+      channel = encodeURIComponent(channel.toLowerCase());
+      channelLinkElem.href = `https://dctech.slack.com/messages/${channel}`;
+      channelElem.textContent = `#${channel}`;
       // Remove "display: none" to unhide.
-      containerElem.style.display = null;
+      channelContainerElem.style.display = null;
     }
   </script>
   </body>


### PR DESCRIPTION
Resolves #7 - Trying out @caseywatts's idea of conditionally showing a 4th step to point invitees to a specific channel. Add `?recommendChannel=hi` to the url. Is this what you had in mind @caseywatts? 

![image](https://user-images.githubusercontent.com/5665333/31748604-5e62cf12-b442-11e7-8221-dc62af50093f.png)


There are probably some edge cases to consider. For example this doesn't scrub the query param, although `?recommendChannel=<script>alert()</script>` properly escapes 😅.  