### PR TITLE
draft

### DIFF
--- a/src/code_of_conduct.html
+++ b/src/code_of_conduct.html
@@ -25,22 +25,24 @@
         </div>
         <div class="measure-wide center tl ma5">
           <div class="f2 tc">Code of Conduct</div>
+          <p><em><strong>By participating in our community, you are subject to this code of conduct. If you are being harassed or offended by a member of the community, notice that someone else is being harassed or offended, or have any other concerns, please contact Jess Szmajda by direct message, @jess.sz. I will respond as promptly as I can.</strong></em></p>
           <p class="info">The DCTech Slack Community exists to provide a space for individuals who live in the greater DC region to communicate, interact, share interesting ideas, and support each other in achieving their goals.</p>
           <p class="info">We hope to create an environment in which all individuals can participate in a positive and affirming way. Behavior that contributes to this sort of environment includes using welcoming and inclusive language, being respectful of differing viewpoints and experiences, gracefully accepting constructive criticism, focusing on what is best for the community at large, and showing empathy towards other community members.</p>
           <p class="info">The DCTech Slack Community is committed to providing an experience that is safe and free from harassment or offense for everyone, regardless of personal attributes such as gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. We expect members to act in good faith to avoid intentionally offending others.</p>
           <p class="info">This code of conduct applies to all public and private channels as well as direct messages. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the admins.</p>
-          <p class="info">If you are being harassed or offended by a member of the community, notice that someone else is being harassed or offended, or have any other concerns, please contact Jess Szmajda by direct message, @jess.sz. I will respond as promptly as I can.</p>
         </div>
       </div>
-      <div class="ph5-ns tc bg-white">
-        <div class="flex flex-wrap space-between">
-          <div class="flex items-center justify-center center">
-            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="/index.html">
-              Back to Main Page
-            </a>
+
+      <div class="flex items-center justify-center center" style="margin-bottom: 20px;">
+        <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="https://dctech-slackin.herokuapp.com/">
+          <div>
+            <div class="f3 mb2">Sign up now!</div>
+            <div>Request Slack Invitation</div>
+            <div class="gray">dctech-slackin.herokuapp.com</div>
           </div>
-        </div>
+        </a>
       </div>
+
     </div>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -16,61 +16,45 @@
 
   <body class="near-black bg-near-white">
     <div class="bg-white mw8 center min-vh-100 shadow-1">
+
       <div class="ph5-ns tc bg-white">
         <div class="center flex items-center justify-center v-mid">
           <div class="center tc db">
             <img src="/dctech-logo.png" style="width: 167px; min-width:167px; height:100px; min-height:100px; "/>
           </div>
-          <div class="f1 flex-auto">Welcome to DCTech Slack</div>
+          <div class="f1 flex-auto">Welcome to the DCTech Slack</div>
         </div>
         <div class="pv3 ph4 ph5-ns lh-copy measure-wide center">
-          We're a free, public Slack for the Washington, DC Tech community. With over 4000 members, we have channels focused on everything from <code>#python</code> to <code>#politics</code>
-          <p class="info">Join us!</p>
+          We're a free, public Slack for the Tech community of the Greater Washington Area. With over 7500 members, we have channels focused on everything from <code>#python</code> to <code>#politics</code>
         </div>
       </div>
+
       <div class="ph5-ns tc bg-white">
         <div class="flex flex-wrap space-between">
+
           <div class="flex items-center justify-center center">
-            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="/code_of_conduct.html">
+            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="./code_of_conduct.html">
               <div>
-                <div class="f3 mb2">1</div>
-                <div>Read</div>
-                <div>The Code of Conduct</div>
+                <div class="f3 mb2">New to our Slack? Start Here!</div>
+                <div>Read the Code of Conduct</div>
               </div>
             </a>
           </div>
-          <div class="flex items-center justify-center center">
-            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="https://dctech-slackin.herokuapp.com/">
-              <div>
-                <div class="f3 mb2">2</div>
-                <div>Request Slack Invitation</div>
-                <div class="gray">dctech-slackin.herokuapp.com</div>
-              </div>
-            </a>
-          </div>
+
           <div class="flex items-center justify-center center">
             <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="http://dctech.slack.com">
               <div>
-                <div class="f3 mb2">3</div>
+                <div class="f3 mb2">Already a Member?</div>
                 <div>Sign in to Slack</div>
                 <div class="gray">dctech.slack.com</div>
               </div>
             </a>
           </div>
-        </div>
-        <div class="flex flex-wrap space-between mt4">
-          <div class="flex items-center justify-center center">
-            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="https://slofile.com/slack/dctech">
-              Slofile:<br />Find other Slacks, or learn more about us
-            </a>
-          </div>
-          <div class="flex items-center justify-center center">
-            <a class="black flex items-center justify-center tc bg-near-white shadow-hover shadow-4 link lh-copy pa3 pa3-ns ma2 h4-ns w5 br2 ba" href="http://dctech.slackarchive.io/">
-              Archived Chat History
-            </a>
-          </div>
+
         </div>
       </div>
+
     </div>
+
   </body>
 </html>


### PR DESCRIPTION
Initial draft for site reorganization.
- Removed two vestigial links from front page.
- Moved the "Request Invite" link from front page to Code of Conduct page.
- Clearly labeled links on front page to direct new members to the Code of Conduct page, and existing members to the slack sign-in page.
- Suggested certain re-wordings on both front page and Code of Conduct.
- Removed "Return to Main Page" button from Code of Conduct page (replaced by the Request Invite button).